### PR TITLE
Node 7 and friends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "node"
+  - "7"
+  - "6"
   - "5"
-  - "5.1"
-  - "6.0"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You will need to set the API token. API tokens can be found in the [project toke
 var I = require('instrumental-node');
 I.configure({
   // from here: https://instrumentalapp.com/docs/tokens
-  apiKey:  'project_api_token',
+  apiKey:  'project_token',
 
   // optional, default shown
   host:    'collector.instrumentalapp.com',

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -38,6 +38,7 @@ class Instrumental {
       debug('Closing Instrumental connection - ' + hadError);
       if (hadError) { this.socket.destroy(); }
       this.socket.removeAllListeners();
+      this.socket.unref();
       this.connected = false;
       this.socket = null;
       if (this.queuedCalls.length > 0) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "instrumental-node",
   "version": "1.0.0",
   "engines": {
-    "node": "5.1"
+    "node": ">=5.1 <=8"
   },
   "description": "Custom metric monitoring for Node applications via Instrumental",
   "repository": {
@@ -19,14 +19,14 @@
     "coverage": "rm -rf coverage; istanbul cover _mocha -- --recursive --reporter spec --bail"
   },
   "dependencies": {
-    "debug": "^2.2.0"
+    "debug": "~2.x"
   },
   "devDependencies": {
-    "jshint": "2.9.1",
-    "mocha": "2.4.5",
-    "should": "8.2.2",
-    "istanbul": "0.4.2",
-    "mitm": "1.2.0"
+    "jshint": "~2.x",
+    "mocha": "~3.x",
+    "should": "~11.x",
+    "istanbul": "~0.x",
+    "mitm": "~1.x"
   },
   "bugs": {
     "url": "https://github.com/instrumental/instrumental-node/issues"


### PR DESCRIPTION
Fixes #14 

* update dependencies across the board to latest and be less restrictive in general about those dependencies
* node 7 (and 6) support
* when we disconnect from instrumental's collectors, we should unref the connection so that apps that depend on the agent shut down in a timely manner
* travis now tests 7 and latest stable node