### PR TITLE
Support for Node 10.x & forces ASCII for socket writes

### DIFF
--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -44,7 +44,7 @@ class Instrumental {
     this.socket.on('connect', () => {
       debug('Authenticating Instrumental connection');
       this.socket.write('hello version node/instrumental_agent/' + VERSION + '\n' +
-                        'authenticate ' + this.apiKey + '\n');
+                        'authenticate ' + this.apiKey + '\n', 'ascii');
     });
 
     this.socket.on('timeout', () => {
@@ -68,7 +68,7 @@ class Instrumental {
       if (data === 'ok\nok\n') {
         debug('Instrumental connected!');
         this.connected = true;
-        this.socket.write(this.queuedCalls.join('\n'));
+        this.socket.write(this.queuedCalls.join('\n'), 'ascii');
         this.queuedCalls = [];
       } else if (data === 'ok\nfail\n') {
         debug('Instrumental authentication failed!');
@@ -96,7 +96,7 @@ class Instrumental {
   record(metricParts) {
     const line = metricParts.join(' ') + '\n';
     if (this.connected) {
-      this.socket.write(line);
+      this.socket.write(line, 'ascii');
     } else {
       if (!this.socket) {
         this.connect();

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -33,8 +33,12 @@ class Instrumental {
     if (this.socket) { return; }
 
     debug('Opening Instrumental connection');
-    this.socket = net.createConnection({ host: this.host, port: 8000 });
+
+    this.socket = new net.Socket();
+    this.socket.connect(8000, this.host);
+
     this.socket.setEncoding('ascii');
+    
     if (this.timeout) { this.socket.setTimeout(this.timeout); }
 
     this.socket.on('connect', () => {

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -34,11 +34,10 @@ class Instrumental {
 
     debug('Opening Instrumental connection');
 
-    this.socket = new net.Socket();
-    this.socket.connect(8000, this.host);
-
-    this.socket.setEncoding('ascii');
+    this.socket = net.connect(8000, this.host);
     
+    this.socket.setEncoding('ascii');
+
     if (this.timeout) { this.socket.setTimeout(this.timeout); }
 
     this.socket.on('connect', () => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "instrumental-agent",
   "version": "2.2.0",
   "engines": {
-    "node": ">=5.1 <10"
+    "node": ">=5.1"
   },
   "description": "Custom metric monitoring for Node applications via Instrumental",
   "repository": {


### PR DESCRIPTION
Closes #22.

The tests still don't pass but it gives me an auth error with the `test` API key and when I use my own API key the test times out even though with `DEBUG=*` I can see everything worked fine.